### PR TITLE
Minor fixes

### DIFF
--- a/oembed/info.go
+++ b/oembed/info.go
@@ -9,7 +9,7 @@ import (
 
 // Info returns information for embedding website
 type Info struct {
-	Status          int    `json:"-,omitempty"`
+	Status          int    `json:"-"`
 	Type            string `json:"type,omitempty"`
 	CacheAge        int64  `json:"cache_age,omitempty"`
 	URL             string `json:"url,omitempty"`


### PR DESCRIPTION
- Properly parse numbers as per the [note in the Gabs README.md](https://github.com/Jeffail/gabs#parsing-numbers).
- Add `,omitempty` to tags to hide empty values.
- Add `cache_age` support as per the oEmbed spec.
- Support `maxwidth` and `maxheight` URL parameters
- Simplify to a single call that accepts a single Options struct allowing users to set the `http.Client`, URL, max width, max height and the Accept-Language header.