### PR TITLE
changes github.com/jeffail/gabs to github.com/Jeffail/gabs

### DIFF
--- a/oembed/info.go
+++ b/oembed/info.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"io"
 
-	"github.com/jeffail/gabs"
+	"github.com/Jeffail/gabs"
 )
 
 // Info returns information for embedding website


### PR DESCRIPTION
Including this project in projects that use `github.com/Jeffail/gabs` break it.

The uppercase version seems to be the official one. 