### PR TITLE
Allow to parse any extra oembed parameter via ExtraOpts

### DIFF
--- a/oembed/oembed.go
+++ b/oembed/oembed.go
@@ -1,6 +1,7 @@
 package oembed
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -54,6 +55,7 @@ type Options struct {
 	MaxWidth       int
 	MaxHeight      int
 	AcceptLanguage string
+	ExtraOpts      map[string]string
 }
 
 // ComposeURL returns url of oembed resource ready to be queried
@@ -95,6 +97,16 @@ func (item *Item) parseOembed(u string, resp *http.Response) (*Info, error) {
 	return info, nil
 }
 
+func buildQueryString(params map[string]string) string {
+	var b bytes.Buffer
+
+	for key, value := range params {
+		b.WriteString(fmt.Sprintf("&%s=%s", key, value))
+	}
+
+	return b.String()
+}
+
 // FetchOembed return oembed info from an url containing it
 func (item *Item) FetchOembed(opts Options) (*Info, error) {
 	resURL := item.ComposeURL(opts.URL)
@@ -105,6 +117,10 @@ func (item *Item) FetchOembed(opts Options) (*Info, error) {
 
 	if opts.MaxHeight > 0 {
 		resURL = fmt.Sprintf("%s&maxheight=%d", resURL, opts.MaxHeight)
+	}
+
+	if len(opts.ExtraOpts) > 0 {
+		resURL = fmt.Sprintf("%s%s", resURL, buildQueryString(opts.ExtraOpts))
 	}
 
 	req, err := http.NewRequest("GET", resURL, nil)


### PR DESCRIPTION
Hey,

we started to use this library in prod now and saw that a lot of the big services use way more parameters than the 4 specified by the offizial oembed definition. Examples are e.g. `autoplay` used by many video services or `dnt` to avoid tracking.

Because the list of available parameters is vendor specific and according to the oembed spec, sending unknown parameters should be ignored by the provider I decided to implement this with a simple `map[string]string` and concatenate the url with `&key=value` pairs.

What do you think of this? I currently use my fork for our codebase and it's working fine for us.

Felix