### PR TITLE
refactor: support context

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	data, err := ioutil.ReadFile("../providers.json")
 
 	if err != nil {
@@ -55,7 +57,7 @@ func main() {
 		item := oe.FindItem(url)
 
 		if item != nil {
-			info, err := item.FetchOembed(oembed.Options{URL: url})
+			info, err := item.FetchOembedCtx(ctx, oembed.Options{URL: url})
 			if err != nil {
 				fmt.Printf("An error occured: %s\n", err.Error())
 			} else {

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strings"
 
@@ -42,6 +44,8 @@ func main() {
 	oe := oembed.NewOembed()
 	oe.ParseProviders(bytes.NewReader(data))
 
+	extras := url.Values{"autoplay": []string{"1"}}
+
 	for {
 
 		reader := bufio.NewReader(os.Stdin)
@@ -57,7 +61,7 @@ func main() {
 		item := oe.FindItem(url)
 
 		if item != nil {
-			info, err := item.FetchOembedCtx(ctx, oembed.Options{URL: url})
+			info, err := item.FetchOembedWithContext(ctx, oembed.Options{URL: url, AcceptLanguage: "en-us", ExtraOpts: extras})
 			if err != nil {
 				fmt.Printf("An error occured: %s\n", err.Error())
 			} else {

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -13,6 +14,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	data, err := ioutil.ReadFile("../providers.json")
 
 	if err != nil {
@@ -39,7 +42,7 @@ func main() {
 		item := oe.FindItem(url)
 
 		if item != nil {
-			info, err := item.FetchOembed(oembed.Options{URL: url, AcceptLanguage: "en-us", ExtraOpts: extras})
+			info, err := item.FetchOembedCtx(ctx, oembed.Options{URL: url, AcceptLanguage: "en-us", ExtraOpts: extras})
 			if err != nil {
 				fmt.Printf("An error occured: %s\n", err.Error())
 			} else {

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -42,7 +42,7 @@ func main() {
 		item := oe.FindItem(url)
 
 		if item != nil {
-			info, err := item.FetchOembedCtx(ctx, oembed.Options{URL: url, AcceptLanguage: "en-us", ExtraOpts: extras})
+			info, err := item.FetchOembedWithContext(ctx, oembed.Options{URL: url, AcceptLanguage: "en-us", ExtraOpts: extras})
 			if err != nil {
 				fmt.Printf("An error occured: %s\n", err.Error())
 			} else {

--- a/oembed/oembed.go
+++ b/oembed/oembed.go
@@ -1,6 +1,7 @@
 package oembed
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -98,6 +99,11 @@ func (item *Item) parseOembed(u string, resp *http.Response) (*Info, error) {
 
 // FetchOembed return oembed info from an url containing it
 func (item *Item) FetchOembed(opts Options) (*Info, error) {
+	return item.FetchOembedWithContext(context.Background(), opts)
+}
+
+// FetchOembedWithContext return oembed info from an url containing it
+func (item *Item) FetchOembedWithContext(ctx context.Context, opts Options) (*Info, error) {
 	resURL := item.ComposeURL(opts.URL)
 
 	params := url.Values{}
@@ -118,7 +124,7 @@ func (item *Item) FetchOembed(opts Options) (*Info, error) {
 		resURL = fmt.Sprintf("%s&%s", resURL, opts.ExtraOpts.Encode())
 	}
 
-	req, err := http.NewRequest("GET", resURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resURL, nil)
 
 	if err != nil {
 		return nil, err
@@ -132,8 +138,7 @@ func (item *Item) FetchOembed(opts Options) (*Info, error) {
 	if opts.Client != nil {
 		resp, err = opts.Client.Do(req)
 	} else {
-		client := &http.Client{}
-		resp, err = client.Do(req)
+		resp, err = http.DefaultClient.Do(req)
 	}
 
 	if err != nil {


### PR DESCRIPTION
1. Add the function `FetchOembedWithContext`.
2. Create a request with `ctx`.
3. Use a default client if not provided.
4. Update the example.