### PR TITLE
Escape periods in URL regex

### DIFF
--- a/oembed/oembed.go
+++ b/oembed/oembed.go
@@ -219,6 +219,7 @@ func (o *Oembed) prepareEndpointURL(url string) string {
 func (o *Oembed) convertSchemaURL2Regexp(url string) *regexp.Regexp {
 	// domain replacements
 	url = strings.Replace(url, "?", "\\?", -1)
+	url = strings.Replace(url, ".", "\\.", -1)
 	url = su2re1.ReplaceAllString(url, "${1}[^/]%?${2}")
 	url = su2re2.ReplaceAllString(url, "${1}.%?${2}")
 	url = su2re3.ReplaceAllString(url, "${1}.%")


### PR DESCRIPTION
Periods in URLs need to be escaped to prevent the regex from matching it as any character.

Example: The Twitter provider generates the following regex `^https://[^/]*?.twitter.com/.*?/status/.*$`, which works for Twitter subdomains, however it also matches things like `fxtwitter.com`.